### PR TITLE
Add video datagram support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ const muxerSenderConfig = {
     }
 ```
 
+Video tracks now support sending each frame using datagrams.  Set
+`moqTracks["video"].moqMapping = MOQ_MAPPING_OBJECT_PER_DATAGRAM` to enable this
+mode (the default continues to use streams per GOP).  Be aware that frames
+larger than the QUIC datagram size will be dropped.
+
 ### src_encoder/index.html
 
 Main encoder webpage and also glues all encoder pieces together

--- a/src-encoder/index.html
+++ b/src-encoder/index.html
@@ -626,25 +626,25 @@ LICENSE file in the root directory of this source tree.
         const optionObjStream = document.createElement('option');
         optionObjStream.value = MOQ_MAPPING_SUBGROUP_PER_GROUP;
         if (moqMappingSelected == MOQ_MAPPING_SUBGROUP_PER_GROUP || moqMappingSelected == undefined) {
-            optionObjStream.selected = true;        
+            optionObjStream.selected = true;
         }
         if (mediaType === "video") {
             optionObjStream.appendChild(document.createTextNode("Subgroup per GOP (AKA: GOP per stream)"));
-            selectElement.appendChild(optionObjStream);
         } else if (mediaType === "audio") {
             optionObjStream.appendChild(document.createTextNode("Subgroup per frame"));
-            selectElement.appendChild(optionObjStream);
-
-            // This protection is because usually IFrames are bigger than a datagram, and allowing to use datagram in video would mean dropping almost all Iframes
-            // Stream per datagram
-            const optionObjTrack = document.createElement('option');
-            optionObjTrack.value = MOQ_MAPPING_OBJECT_PER_DATAGRAM;
-            if (moqMappingSelected == MOQ_MAPPING_OBJECT_PER_DATAGRAM) {
-                optionObjStream.selected = true;        
-            }
-            optionObjTrack.appendChild(document.createTextNode("Object per datagram (AKA: Frame per datagram)"));
-            selectElement.appendChild(optionObjTrack);
+        } else {
+            optionObjStream.appendChild(document.createTextNode("Subgroup per object"));
         }
+        selectElement.appendChild(optionObjStream);
+
+        // Stream per datagram
+        const optionObjTrack = document.createElement('option');
+        optionObjTrack.value = MOQ_MAPPING_OBJECT_PER_DATAGRAM;
+        if (moqMappingSelected == MOQ_MAPPING_OBJECT_PER_DATAGRAM) {
+            optionObjTrack.selected = true;
+        }
+        optionObjTrack.appendChild(document.createTextNode("Object per datagram (AKA: Frame per datagram)"));
+        selectElement.appendChild(optionObjTrack);
     }
 
     function initStreamIDUI() {

--- a/src-vc/index.html
+++ b/src-vc/index.html
@@ -742,24 +742,25 @@ LICENSE file in the root directory of this source tree.
         const optionObjStream = document.createElement('option');
         optionObjStream.value = MOQ_MAPPING_SUBGROUP_PER_GROUP;
         if (moqMappingSelected == MOQ_MAPPING_SUBGROUP_PER_GROUP || moqMappingSelected == undefined) {
-            optionObjStream.selected = true;        
+            optionObjStream.selected = true;
         }
         if (mediaType === "video") {
             optionObjStream.appendChild(document.createTextNode("Subgroup per GOP (AKA: GOP per stream)"));
-            selectElement.appendChild(optionObjStream);
         } else if (mediaType === "audio") {
             optionObjStream.appendChild(document.createTextNode("Subgroup per frame"));
-            selectElement.appendChild(optionObjStream);
-            // This protection is because usually IFrames are bigger than a datagram, and allowing to use datagram in video would mean dropping almost all Iframes
-            // Stream per datagram
-            const optionObjTrack = document.createElement('option');
-            optionObjTrack.value = MOQ_MAPPING_OBJECT_PER_DATAGRAM;
-            if (moqMappingSelected == MOQ_MAPPING_OBJECT_PER_DATAGRAM) {
-                optionObjStream.selected = true;        
-            }
-            optionObjTrack.appendChild(document.createTextNode("Object per datagram (AKA: Frame per datagram)"));
-            selectElement.appendChild(optionObjTrack);
+        } else {
+            optionObjStream.appendChild(document.createTextNode("Subgroup per object"));
         }
+        selectElement.appendChild(optionObjStream);
+
+        // Stream per datagram
+        const optionObjTrack = document.createElement('option');
+        optionObjTrack.value = MOQ_MAPPING_OBJECT_PER_DATAGRAM;
+        if (moqMappingSelected == MOQ_MAPPING_OBJECT_PER_DATAGRAM) {
+            optionObjTrack.selected = true;
+        }
+        optionObjTrack.appendChild(document.createTextNode("Object per datagram (AKA: Frame per datagram)"));
+        selectElement.appendChild(optionObjTrack);
     }
 
     function encoderProcessWorkerMessage(e) {


### PR DESCRIPTION
## Summary
- enable datagram mode for video tracks in encoder UIs
- document how to enable video datagrams

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846b06aa3ac83229341cf9e19f47f6d